### PR TITLE
Fix bug where get_backend_by_name found partial matches

### DIFF
--- a/lib/timeseries.c
+++ b/lib/timeseries.c
@@ -145,7 +145,7 @@ timeseries_backend_t *timeseries_get_backend_by_name(timeseries_t *timeseries,
   TIMESERIES_FOREACH_BACKEND_ID(id)
   {
     if ((backend = timeseries_get_backend_by_id(timeseries, id)) != NULL &&
-        strncasecmp(backend->name, name, strlen(backend->name)) == 0) {
+        strcasecmp(backend->name, name) == 0) {
       return backend;
     }
   }


### PR DESCRIPTION
Becuase we were only comparing strings up to the length of the backend name, invalid backend names that began with a valid backend name would be incorrectly matched. E.g., "netacq-edge-XXX" would be found to match "netacq-edge".