### PR TITLE
Add ASCII format for Kafka backend

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtimeseries0 (1.0.0) unstable; urgency=medium
+
+  * Adds ascii output format to kafka backend
+
+ -- Alistair King <software@caida.org>  Thu, 25 Mar 2020 14:24:38 -0700
+
 libtimeseries0 (0.2.0-1) unstable; urgency=medium
 
   * Fix build-time dependency on libwandio and librdkafka

--- a/lib/backends/timeseries_backend_kafka.c
+++ b/lib/backends/timeseries_backend_kafka.c
@@ -565,6 +565,7 @@ void timeseries_backend_kafka_free(timeseries_backend_t *backend)
 
   if (state->rdk_conn != NULL) {
     int drain_wait_cnt = 12;
+    rd_kafka_poll(state->rdk_conn, 0);
     while (rd_kafka_outq_len(state->rdk_conn) > 0 && drain_wait_cnt > 0) {
       timeseries_log(
         __func__,

--- a/tools/tsk-proxy.c
+++ b/tools/tsk-proxy.c
@@ -114,7 +114,7 @@
 #define HEADER_LEN (HEADER_MAGIC_LEN + 1 + 4 + 2)
 
 // Timeout for kafka consumer poll in milliseconds.
-#define KAFKA_POLL_TIMEOUT 10 * 1000
+#define KAFKA_POLL_TIMEOUT 1 * 1000
 
 // Buffer length to hold key package keys.
 #define KEY_BUF_LEN 1024
@@ -550,7 +550,7 @@ int run(rd_kafka_t *kafka, const tsk_config_t *cfg)
         eof_since_data = 0;
       } else if (rkmessage->err == RD_KAFKA_RESP_ERR__PARTITION_EOF) {
         LOG_DEBUG("Reached end of partition.\n");
-        if (++eof_since_data >= 10) {
+        if (shutdown_proxy || ++eof_since_data >= 10) {
           rd_kafka_message_destroy(rkmessage);
           break;
         }


### PR DESCRIPTION
This will allow us to connect telegraf proxy instances directly to TSK topics to ingest graphite-formatted data into InfluxDB.