### PR TITLE
Fix bug in timestamp-based partitioning for TSK

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,12 +31,12 @@
 
 AC_PREREQ([2.68])
 
-AC_INIT([libtimeseries], [1.0.1], [corsaro-info@caida.org])
+AC_INIT([libtimeseries], [1.0.2], [corsaro-info@caida.org])
 AM_INIT_AUTOMAKE([foreign])
 
 LIBTIMESERIES_MAJOR_VERSION=1
 LIBTIMESERIES_MID_VERSION=0
-LIBTIMESERIES_MINOR_VERSION=0
+LIBTIMESERIES_MINOR_VERSION=2
 
 # since libtimeseries is only a library, the version numbers are only used to
 # set the libtool library verson numbers. This means that the numbering is

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libtimeseries0 (1.0.2) unstable; urgency=medium
+
+  * Fix bug in partition assignment for TSK messages
+
+ -- Shane Alcock <software@caida.org>  Wed, 19 May 2021 14:22:19 +1200
+
 libtimeseries0 (1.0.1) unstable; urgency=medium
 
   * Fix bug that could cause deadlock when producer queue is full

--- a/lib/backends/timeseries_backend_kafka.c
+++ b/lib/backends/timeseries_backend_kafka.c
@@ -93,9 +93,10 @@ typedef enum {
 #define SEND_MSG(partition, buf, written, time, ptr, len)                      \
   do {                                                                         \
     int success = 0;                                                           \
+    uint32_t swaptime = htonl(time);                                           \
     while (written > 0 && success == 0) {                                      \
       if (rd_kafka_produce(state->rkt, (partition), RD_KAFKA_MSG_F_COPY,       \
-                           (buf), (written), &(time), sizeof(time),            \
+                           (buf), (written), &(swaptime), sizeof(swaptime),    \
                            NULL) == -1) {                                      \
         if (rd_kafka_last_error() == RD_KAFKA_RESP_ERR__QUEUE_FULL) {          \
           timeseries_log(__func__, "WARN: producer queue full, retrying...");  \
@@ -261,7 +262,7 @@ static int parse_args(timeseries_backend_t *backend, int argc, char **argv)
 
   if (state->broker_uri == NULL) {
     fprintf(stderr, "ERROR: Kafka Broker URI(s) must be specified using -b\n");
-    usage(backend);
+    usage(backend); 
     return -1;
   }
 


### PR DESCRIPTION
The byte ordering of the timestamp was incorrect when provided as a message key to rdkafka, so our partition calculation was based on a byteswapped timestamp (on little-endian hosts, at least).

In practice, this usually meant that 50% of available partitions were being assigned to and the intervals were not being round robinned as intended.