### PR TITLE
Add new kafka partitioning method: 'tskkey'

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,12 +31,12 @@
 
 AC_PREREQ([2.68])
 
-AC_INIT([libtimeseries], [1.0.2], [corsaro-info@caida.org])
+AC_INIT([libtimeseries], [1.0.3], [corsaro-info@caida.org])
 AM_INIT_AUTOMAKE([foreign])
 
 LIBTIMESERIES_MAJOR_VERSION=1
 LIBTIMESERIES_MID_VERSION=0
-LIBTIMESERIES_MINOR_VERSION=2
+LIBTIMESERIES_MINOR_VERSION=3
 
 # since libtimeseries is only a library, the version numbers are only used to
 # set the libtool library verson numbers. This means that the numbering is

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libtimeseries0 (1.0.3) unstable; urgency=medium
+
+  * Add new kafka format: 'tskkey', which will partition data based
+    on their series key string.
+
+ -- Shane Alcock <software@caida.org>  Thu, 20 May 2021 18:53:27 +1200
+
 libtimeseries0 (1.0.2) unstable; urgency=medium
 
   * Fix bug in partition assignment for TSK messages

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -64,7 +64,7 @@ libtimeseries_la_LIBADD = 			\
 	$(top_builddir)/common/libcccommon.la 	\
 	$(top_builddir)/lib/backends/libtimeseries_backends.la
 
-libtimeseries_la_LDFLAGS = -version-info @LIBTIMESERIES_MAJOR_VERSION@:@LIBTIMESERIES_MID_VERSION@:@LIBTIMESERIES_MINOR_VERSION@
+libtimeseries_la_LDFLAGS = -version-info 1:1:0
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/lib/backends/timeseries_backend_kafka.c
+++ b/lib/backends/timeseries_backend_kafka.c
@@ -669,7 +669,7 @@ int timeseries_backend_kafka_kp_flush(timeseries_backend_t *backend,
   ssize_t s = 0;
   uint32_t thishash = 0, lasthash = 0, msgkey = 0;
   const char *key = NULL;
-  char *keydup, *sptr;
+  char *sptr;
 
   assert(state->buffer_written == 0);
 


### PR DESCRIPTION
If the format is set to 'tskkey', data is assigned to a kafka
partition based on a hash of the series key (minus the last
term in the key, e.g. "pkt_cnt", "ip_len" etc for corsaro time
series data).

This means that all data points for a given series (and any
directly related series) will end up on the same partition. This
allows parallel kafka consumers in the same consumer group to be
guaranteed that they will see the full time series for any key
that they see, rather than it being spread across all consumers.

Default partitioning remains "tsk" for now.

