### PR TITLE
Set -Werror on build and fix outstanding warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,7 @@
 #
 
 SUBDIRS = common lib tools
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/common \
+AM_CPPFLAGS = -Wall -Werror -I$(top_srcdir) -I$(top_srcdir)/common \
 	-I$(top_srcdir)/lib \
 	-I$(top_srcdir)/lib/backends
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -31,8 +31,8 @@
 
 SUBDIRS = backends
 
-AM_CPPFLAGS = 	-I$(top_srcdir) 	\
-		-I$(top_srcdir)/common 	\
+AM_CPPFLAGS = 	-Wall -Werror -I$(top_srcdir) 	\
+		-I$(top_srcdir)/common 	        \
 		-I$(top_srcdir)/lib/backends
 
 lib_LTLIBRARIES = libtimeseries.la

--- a/lib/backends/Makefile.am
+++ b/lib/backends/Makefile.am
@@ -33,7 +33,8 @@ SUBDIRS =
 
 AM_CPPFLAGS = 	-I$(top_srcdir)		\
 		-I$(top_srcdir)/common 	\
-		-I$(top_srcdir)/lib
+		-I$(top_srcdir)/lib     \
+                -Wall -Werror
 
 noinst_LTLIBRARIES = libtimeseries_backends.la
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -32,6 +32,7 @@
 AM_CPPFLAGS = 	-I$(top_srcdir) 	\
 		-I$(top_srcdir)/common 	\
 		-I$(top_srcdir)/lib 	\
+                -Wall -Werror           \
 		-I$(top_srcdir)/lib/backends
 
 dist_bin_SCRIPTS =


### PR DESCRIPTION
Our packaging system sets -Werror when building packages, so we
can run into problems where the code builds and runs fine in
development but cannot be packaged.

Enables -Werror and -Wall on all build directories, and fixes
all outstanding warnings that were causing the packaging to
fail.