### PR TITLE
Fix `timeseries-insert` build failures for newer gcc 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,12 +31,12 @@
 
 AC_PREREQ([2.68])
 
-AC_INIT([libtimeseries], [1.0.3], [corsaro-info@caida.org])
+AC_INIT([libtimeseries], [1.0.4], [corsaro-info@caida.org])
 AM_INIT_AUTOMAKE([foreign])
 
 LIBTIMESERIES_MAJOR_VERSION=1
 LIBTIMESERIES_MID_VERSION=0
-LIBTIMESERIES_MINOR_VERSION=3
+LIBTIMESERIES_MINOR_VERSION=4
 
 
 # since libtimeseries is only a library, the version numbers are only used to

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+libtimeseries0 (1.0.4) unstable; urgency=medium
+
+  * Fix bad error message in timeseries-insert tool
+  * Fix bug where 'tskkey' was not supported in the set_single
+    callback for kafka.
+
+ -- Shane Alcock <software@caida.org>  Thu, 03 Jun 2021 13:51:50 +1200
+
 libtimeseries0 (1.0.3) unstable; urgency=medium
 
   * Add new kafka format: 'tskkey', which will partition data based

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -64,7 +64,7 @@ libtimeseries_la_LIBADD = 			\
 	$(top_builddir)/common/libcccommon.la 	\
 	$(top_builddir)/lib/backends/libtimeseries_backends.la
 
-libtimeseries_la_LDFLAGS = -version-info 1:1:0
+libtimeseries_la_LDFLAGS = -version-info 1:2:0
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/tools/timeseries-insert.c
+++ b/tools/timeseries-insert.c
@@ -75,7 +75,7 @@ static int insert(char *line)
   /* get the key string */
   if ((key = strsep(&line, " ")) == NULL) {
     /* malformed line */
-    fprintf(stderr, "ERROR: Malformed metric record (missing key): %s\n", key);
+    fprintf(stderr, "ERROR: Malformed metric record (missing key): %s\n", line);
     return 0;
   }
 


### PR DESCRIPTION
Also bumps version to 1.0.4